### PR TITLE
Assume that ALTLIST methods are non-allocating (llvm14 branch)

### DIFF
--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -41,6 +41,10 @@ bool isAssertedNonAllocating(Function *f) {
   if (f->getName() == "ALTSTRING_ELT") return true;
   
   if (f->getName() == "ALTSTRING_SET_ELT") return true;
+
+  if (f->getName() == "ALTLIST_ELT") return true;
+
+  if (f->getName() == "ALTLIST_SET_ELT") return true;
   
   if (f->getName() == "ALTINTEGER_MIN") return true;  
   if (f->getName() == "ALTINTEGER_MAX") return true;


### PR DESCRIPTION
Similarly to ALTSTRING methods. 

Same as #32, for the `llvm14` branch.